### PR TITLE
Add tri-planar MPR view with interactive crosshairs

### DIFF
--- a/VolumeRendering-iOS.xcodeproj/project.pbxproj
+++ b/VolumeRendering-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		121180022E873D1B00EA1DB6 /* TriPlanarMPR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121180012E873D1B00EA1DB6 /* TriPlanarMPR.swift */; };
 		126AB2192E872A5500051910 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 126AB2182E872A5500051910 /* AVKit.framework */; };
 		12CB89792E86CF76009C2E22 /* mpr.metal in Sources */ = {isa = PBXBuildFile; fileRef = 12CB89772E86CF76009C2E22 /* mpr.metal */; };
 		12CB897A2E86CF76009C2E22 /* MPRPlaneMaterial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CB89782E86CF76009C2E22 /* MPRPlaneMaterial.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		121180012E873D1B00EA1DB6 /* TriPlanarMPR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriPlanarMPR.swift; sourceTree = "<group>"; };
 		126AB2182E872A5500051910 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		12CB89762E86CF76009C2E22 /* DICOMGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DICOMGeometry.swift; sourceTree = "<group>"; };
 		12CB89772E86CF76009C2E22 /* mpr.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = mpr.metal; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 		66320B4628430A3B005D3347 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				121180012E873D1B00EA1DB6 /* TriPlanarMPR.swift */,
 				9C21FBCC27A0D860004CE254 /* SceneView.swift */,
 				9C8B3E6B279E8AA600599C97 /* ContentView.swift */,
 				9C8B3E69279E8AA600599C97 /* VolumeRendering_iOSApp.swift */,
@@ -281,6 +284,7 @@
 				66072805284328D80028EE15 /* shared.metal in Sources */,
 				9C21FBCF27A0E904004CE254 /* VolumeTexture.swift in Sources */,
 				E395877B27A3C445003F54D1 /* TransferFunction.swift in Sources */,
+				121180022E873D1B00EA1DB6 /* TriPlanarMPR.swift in Sources */,
 				9C21FBCD27A0D860004CE254 /* SceneView.swift in Sources */,
 				12CB89792E86CF76009C2E22 /* mpr.metal in Sources */,
 				12CB897A2E86CF76009C2E22 /* MPRPlaneMaterial.swift in Sources */,

--- a/VolumeRendering-iOS/Source/View/ContentView.swift
+++ b/VolumeRendering-iOS/Source/View/ContentView.swift
@@ -265,7 +265,7 @@ struct DrawOptionView: View {
 
             // === Em MPR, o controle de navegação é pelas linhas; removi o slider de fatia ===
             if model.method == .mpr {
-                Text("Tri‑Planar ativo: arraste as linhas nos 3 painéis para navegar; use rotação de 2 dedos para MPR oblíquo.")
+                Text("Tri‑Planar active: drag the lines in the 3 panels to navigate; use 2-finger rotation for oblique MPR.")
                     .foregroundColor(.white)
                     .font(.footnote)
             }

--- a/VolumeRendering-iOS/Source/View/ContentView.swift
+++ b/VolumeRendering-iOS/Source/View/ContentView.swift
@@ -11,15 +11,27 @@ struct ContentView: View {
     
     var body: some View {
         ZStack(alignment: .topLeading) {
-            SceneView(scnView: view)
-                .background(.gray)
-                .onAppear(perform: {
-                    if !isInitialized {
-                        SceneViewController.Instance.onAppear(view)
-                        isInitialized = true
-                    }
-                })
+            // === VR 3D ou Tri‑Planar MPR (3 painéis) ===
+            Group {
+                if model.method == .mpr {
+                    // Painel Tri‑Planar
+                    TriPlanarMPRView()
+                        .environmentObject(model)
+                } else {
+                    // Pipeline 3D original
+                    SceneView(scnView: view)
+                }
+            }
+            .background(.gray)
+            .onAppear {
+                if !isInitialized {
+                    // Inicializa device/texturas no controller principal (mesmo que o Tri‑Planar esteja ativo)
+                    SceneViewController.Instance.onAppear(view)
+                    isInitialized = true
+                }
+            }
                
+            // === Painel de opções (o seu, intacto) ===
             HStack(alignment: .top) {
                 Button(showOption ? "hide" : "show") {
                     showOption.toggle()
@@ -33,11 +45,13 @@ struct ContentView: View {
                     .frame(maxWidth: 420, maxHeight: 360, alignment: .topLeading)
                     .background(.clear)
                 }
-            }.padding(.vertical, 25)
+            }
+            .padding(.vertical, 25)
         }
     }
 }
 
+// === MODELO (o seu, sem mudanças) ===
 class DrawOptionModel: ObservableObject {
     @Published var part = VolumeCubeMaterial.BodyPart.none
     @Published var method = SceneViewController.RenderMode.dvr
@@ -58,7 +72,8 @@ class DrawOptionModel: ObservableObject {
     @Published var huMaxHU: Float = -500
     @Published var useTFMpr: Bool = true
 
-    // MPR básico
+    // MPR básico (os dois abaixo não são mais necessários para o tri‑planar,
+    // mas mantive para compatibilidade com seu SceneViewController)
     @Published var mprOn: Bool = false
     @Published var mprBlend: MPRPlaneMaterial.BlendMode = .single
     @Published var mprAxialSlice: Float = 0
@@ -66,6 +81,7 @@ class DrawOptionModel: ObservableObject {
     @Published var mprPlane: MPRPlane = .axial
 }
 
+// === VIEW DO PAINEL (o seu, com 1 ajuste no trecho final do MPR) ===
 struct DrawOptionView: View {
     @ObservedObject var model: DrawOptionModel
     
@@ -162,6 +178,7 @@ struct DrawOptionView: View {
 
             HStack {
                 Toggle("TF no MPR", isOn: $model.useTFMpr)
+                    // O Tri‑Planar observa esta flag e aplica em todos os 3 painéis
                     .onChange(of: model.useTFMpr) { SceneViewController.Instance.setMPRUseTF($0) }
             }.frame(height: 30)
 
@@ -180,6 +197,7 @@ struct DrawOptionView: View {
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
+                // O Tri‑Planar observa esta seleção e replica nos 3 painéis
                 .onChange(of: model.mprBlend) { SceneViewController.Instance.setMPRBlend($0) }
             }.frame(height: 30)
 
@@ -245,36 +263,11 @@ struct DrawOptionView: View {
                     .onChange(of: model.adaptiveOn) { SceneViewController.Instance.setAdaptive($0) }
             }.frame(height: 30)
 
+            // === Em MPR, o controle de navegação é pelas linhas; removi o slider de fatia ===
             if model.method == .mpr {
-                // Picker do plano
-                HStack {
-                    Picker("Plano MPR", selection: $model.mprPlane) {
-                        ForEach(DrawOptionModel.MPRPlane.allCases, id: \.self) {
-                            Text($0.rawValue)
-                        }
-                    }
-                    .pickerStyle(SegmentedPickerStyle())
-                    .onChange(of: model.mprPlane) { SceneViewController.Instance.setMPRPlane($0) }
-                }.frame(height: 30)
-
-                // Slider da fatia (dinâmico por plano)
-                HStack {
-                    Text("\(model.mprPlane.rawValue.capitalized) Slice").foregroundColor(.white)
-                    Slider(
-                        value: Binding(
-                            get: { Double(model.mprAxialSlice) },
-                            set: { model.mprAxialSlice = Float($0) }
-                        ),
-                        in: 0.0...1.0,
-                        step: {
-                            let n = max(1, SceneViewController.Instance.mprDimCurrent)
-                            return n > 1 ? 1.0 / Double(n - 1) : 0.01
-                        }()
-                    )
-                    .padding()
-                    .onChange(of: model.mprAxialSlice) { SceneViewController.Instance.updateSlice(normalizedValue: $0) }
-                }
-                .frame(height: 30)
+                Text("Tri‑Planar ativo: arraste as linhas nos 3 painéis para navegar; use rotação de 2 dedos para MPR oblíquo.")
+                    .foregroundColor(.white)
+                    .font(.footnote)
             }
         }
     }

--- a/VolumeRendering-iOS/Source/View/SceneViewController.swift
+++ b/VolumeRendering-iOS/Source/View/SceneViewController.swift
@@ -34,6 +34,7 @@ class SceneViewController: NSObject {
     private var mprAxNode: SCNNode?
     private var mprCoNode: SCNNode?
     private var mprSaNode: SCNNode?
+
     
     override public init() { super.init() }
 
@@ -389,5 +390,24 @@ class SceneViewController: NSObject {
         if axis == 0 { mpr.setSagittal(column:Int((mpr.dimension.x)/2)) }
 
         return node
+    }
+}
+
+// MARK: - Exposição mínima para o painel Tri‑Planar
+extension SceneViewController {
+    /// Textura 3D do volume atualmente carregado (compartilhável entre materiais MPR).
+    func currentVolumeTexture() -> MTLTexture? {
+        (mat.value(forKey: "dicom") as? SCNMaterialProperty)?.contents as? MTLTexture
+    }
+
+    /// Textura 1D da Transfer Function usada no VR (reutilizada no MPR).
+    func currentTFTexture() -> MTLTexture? {
+        (mat.value(forKey: "transferColor") as? SCNMaterialProperty)?.contents as? MTLTexture
+    }
+
+    /// Dimensão (voxels) e resolução (mm/voxel) do dataset atual.
+    func currentDatasetMeta() -> (dimension: int3, resolution: float3)? {
+        if let d = mprMat?.dimension, let r = mprMat?.resolution { return (d, r) }
+        return nil
     }
 }

--- a/VolumeRendering-iOS/Source/View/TriPlanarMPR.swift
+++ b/VolumeRendering-iOS/Source/View/TriPlanarMPR.swift
@@ -1,0 +1,321 @@
+//  TriPlanarMPR.swift
+//  Isis DICOM Viewer
+//
+//  Tri‑Planar MPR com linhas ortogonais arrastáveis e rotação oblíqua
+//  - 3 viewports 2D (axial, coronal, sagital) com SCNView ortográfico
+//  - Reutiliza a textura 3D e a TF já carregadas pelo VR
+//  - Linhas centrais arrastáveis movem os planos; rotação 2‑toques gira a triade
+//
+//  Thales Matheus Mendonça Santos - September 2025
+
+import SwiftUI
+import SceneKit
+import simd
+
+// MARK: - Enum de planos
+enum TriPlane: CaseIterable {
+    case axial, coronal, sagittal
+    var title: String {
+        switch self {
+        case .axial: return "Axial"
+        case .coronal: return "Coronal"
+        case .sagittal: return "Sagittal"
+        }
+    }
+}
+
+// MARK: - Estado compartilhado (triade ortonormal + ponto de interseção)
+final class TriMPRState: ObservableObject {
+    // Base {x',y',z'} (colunas) em coords normalizadas do volume [0,1]^3
+    @Published var R: simd_float3x3 = matrix_identity_float3x3
+    // Ponto de interseção (crosshair) em [0,1]^3
+    @Published var cross: SIMD3<Float> = SIMD3(0.5, 0.5, 0.5)
+
+    // clamps
+    private let eps: Float = 1e-5
+
+    // Accessor for matrix column by index (since `columns` is a tuple, not subscriptable)
+    private func baseColumn(_ i: Int) -> SIMD3<Float> {
+        switch i {
+        case 0: return R.columns.0
+        case 1: return R.columns.1
+        default: return R.columns.2
+        }
+    }
+
+    // Rotação incremental ao redor de um eixo da própria base (0=x', 1=y', 2=z').
+    func rotate(aroundBaseAxis i: Int, deltaRadians: Float) {
+        let axis = normalize(baseColumn(i))
+        let c = cos(deltaRadians), s = sin(deltaRadians)
+        let C = 1 - c
+        let x = axis.x, y = axis.y, z = axis.z
+        let rot = simd_float3x3(
+            SIMD3<Float>( c + x*x*C,     x*y*C - z*s,  x*z*C + y*s),
+            SIMD3<Float>( y*x*C + z*s,   c + y*y*C,    y*z*C - x*s),
+            SIMD3<Float>( z*x*C - y*s,   z*y*C + x*s,  c + z*z*C)
+        )
+        R = rot * R
+    }
+
+    // Tradução do cross ao longo de um eixo da base (0=x',1=y',2=z')
+    func translate(alongBaseAxis i: Int, deltaNormalized: Float) {
+        cross = simd_clamp(cross + deltaNormalized * baseColumn(i),
+                           SIMD3<Float>(repeating: 0 + eps),
+                           SIMD3<Float>(repeating: 1 - eps))
+    }
+}
+
+// MARK: - Um viewport (SCNView) para um plano
+final class MPRViewportController: NSObject {
+    let planeKind: TriPlane
+    private let scnView = SCNView()
+    private let scene = SCNScene()
+    private let cameraNode = SCNNode()
+    private let node = SCNNode(geometry: SCNPlane(width: 1, height: 1))
+    private let matMPR: MPRPlaneMaterial
+    private var device: MTLDevice
+
+    init?(plane: TriPlane, device: MTLDevice) {
+        self.planeKind = plane
+        guard let dev = device as MTLDevice? else { return nil }
+        self.device = dev
+        self.matMPR = MPRPlaneMaterial(device: dev)
+        super.init()
+        setupView()
+    }
+
+    var view: SCNView { scnView }
+
+    private func setupView() {
+        scnView.scene = scene
+        scnView.backgroundColor = .black
+        scnView.allowsCameraControl = false
+        scnView.autoenablesDefaultLighting = true
+
+        // Câmera ortográfica 2D
+        cameraNode.camera = SCNCamera()
+        cameraNode.camera?.usesOrthographicProjection = true
+        cameraNode.camera?.orthographicScale = 1.0      // plano 1×1 em tela
+        cameraNode.position = SCNVector3(0, 0, 2)
+        cameraNode.camera?.zNear = 0.001
+        cameraNode.camera?.zFar  = 10
+        scene.rootNode.addChildNode(cameraNode)
+
+        node.geometry?.firstMaterial = matMPR
+        node.eulerAngles = SCNVector3Zero
+        node.position = SCNVector3Zero
+        scene.rootNode.addChildNode(node)
+    }
+
+    // Injeta dataset (textura 3D, TF, meta)
+    func setDataset(volumeTex: MTLTexture, tfTex: MTLTexture?, dimension: int3, resolution: float3) {
+        matMPR.setValue(SCNMaterialProperty(contents: volumeTex), forKey: "volume")
+        if let tf = tfTex { matMPR.setTransferFunction(tf) }
+        matMPR.setDataset(dimension: dimension, resolution: resolution)
+        // MPR fino por padrão
+        matMPR.setSlab(thicknessInVoxels: 0, axis: 2, steps: 1)
+    }
+
+    // Aplica obliquidade e posição do plano a partir de base R e cross
+    func apply(R: simd_float3x3, cross: SIMD3<Float>) {
+        // Triade {x',y',z'} (colunas)
+        let xp = R.columns.0
+        let yp = R.columns.1
+        let zp = R.columns.2
+
+        // u/v por plano
+        let (u, v): (SIMD3<Float>, SIMD3<Float>)
+        switch planeKind {
+        case .axial:    (u, v) = (xp, yp)   // normal = z'
+        case .coronal:  (u, v) = (xp, zp)   // normal = y'
+        case .sagittal: (u, v) = (yp, zp)   // normal = x'
+        }
+
+        // origem no canto inferior‑esquerdo, centrando cross (u=v=0.5)
+        let origin = cross - 0.5 * (u + v)
+        matMPR.setOblique(origin: float3(origin), axisU: float3(u), axisV: float3(v))
+        // A geometria é sempre 1×1; não precisa girar o node: o shader resolve a amostra 3D
+    }
+}
+
+// MARK: - Representable para SwiftUI
+struct MPRViewportView: UIViewRepresentable {
+    typealias UIViewType = SCNView
+
+    let controller: MPRViewportController
+
+    func makeUIView(context: Context) -> SCNView { controller.view }
+    func updateUIView(_ uiView: SCNView, context: Context) {}
+}
+
+// MARK: - Overlay com linhas/gestos
+struct CrosshairOverlay: View {
+    // callbacks
+    let onDragVertical: (CGFloat, CGSize) -> Void   // (width, translation)
+    let onDragHorizontal: (CGFloat, CGSize) -> Void // (height, translation)
+    let onRotate: (CGFloat) -> Void                 // delta em radianos
+
+    // estados internos do gesto de rotação
+    @State private var lastAngle: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let h = geo.size.height
+            ZStack {
+                // Linha vertical (controla x')
+                Path { p in
+                    p.move(to: CGPoint(x: w/2, y: 0))
+                    p.addLine(to: CGPoint(x: w/2, y: h))
+                }
+                .stroke(.yellow, lineWidth: 2)
+                // área de toque mais larga
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: 44, height: h)
+                    .position(x: w/2, y: h/2)
+                    .gesture(DragGesture(minimumDistance: 0)
+                        .onChanged { value in onDragVertical(w, value.translation) })
+
+                // Linha horizontal (controla y' ou z', conforme plano)
+                Path { p in
+                    p.move(to: CGPoint(x: 0, y: h/2))
+                    p.addLine(to: CGPoint(x: w, y: h/2))
+                }
+                .stroke(.purple, lineWidth: 2)
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: w, height: 44)
+                    .position(x: w/2, y: h/2)
+                    .gesture(DragGesture(minimumDistance: 0)
+                        .onChanged { value in onDragHorizontal(h, value.translation) })
+
+                // “alça” central + gesto de rotação de 2 dedos
+                Circle()
+                    .stroke(.white.opacity(0.9), lineWidth: 2)
+                    .frame(width: 22, height: 22)
+                    .position(x: w/2, y: h/2)
+            }
+            // rotação oblíqua (2 dedos)
+            .gesture(RotationGesture()
+                .onChanged { value in
+                    let delta = value.radians - lastAngle
+                    lastAngle = value.radians
+                    onRotate(delta)
+                }
+                .onEnded { _ in lastAngle = 0 })
+        }
+    }
+}
+
+// MARK: - Painel Tri‑Planar (3 viewports)
+struct TriPlanarMPRView: View {
+    @StateObject private var state = TriMPRState()
+
+    private let axialVC: MPRViewportController
+    private let coronalVC: MPRViewportController
+    private let sagittalVC: MPRViewportController
+
+    init?() {
+        // Reutiliza device/volume/TF do controller principal
+        guard let device = SceneViewController.Instance.device else { return nil }
+        guard let ax = MPRViewportController(plane: .axial, device: device),
+              let co = MPRViewportController(plane: .coronal, device: device),
+              let sa = MPRViewportController(plane: .sagittal, device: device)
+        else { return nil }
+        self.axialVC = ax; self.coronalVC = co; self.sagittalVC = sa
+
+        // Dataset atual
+        if let vol = SceneViewController.Instance.currentVolumeTexture(),
+           let meta = SceneViewController.Instance.currentDatasetMeta() {
+            let tf = SceneViewController.Instance.currentTFTexture()
+            [axialVC, coronalVC, sagittalVC].forEach {
+                $0.setDataset(volumeTex: vol, tfTex: tf,
+                              dimension: meta.dimension, resolution: meta.resolution)
+            }
+            // aplica estado inicial (R=I, cross=centro)
+            [axialVC, coronalVC, sagittalVC].forEach { $0.apply(R: matrix_identity_float3x3, cross: SIMD3(0.5,0.5,0.5)) }
+        }
+    }
+
+    // Aplica R/cross em todos
+    private func syncAll() {
+        [axialVC, coronalVC, sagittalVC].forEach { $0.apply(R: state.R, cross: state.cross) }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack(spacing: 6) {
+                // Topo: Axial (ocupando largura toda)
+                ZStack {
+                    MPRViewportView(controller: axialVC).background(Color.black)
+                    CrosshairOverlay(
+                        onDragVertical: { width, t in
+                            // mover x' (eixo da linha vertical) — usa deltaX/width
+                            state.translate(alongBaseAxis: 0, deltaNormalized: Float(t.width / width))
+                            syncAll()
+                        },
+                        onDragHorizontal: { height, t in
+                            // mover y' — usa -deltaY/height (origem UI no topo)
+                            state.translate(alongBaseAxis: 1, deltaNormalized: Float(-t.height / height))
+                            syncAll()
+                        },
+                        onRotate: { deltaRad in
+                            // girar ao redor de z' (normal do axial)
+                            state.rotate(aroundBaseAxis: 2, deltaRadians: Float(deltaRad))
+                            syncAll()
+                        }
+                    )
+                    .allowsHitTesting(true)
+                }
+                .frame(height: geo.size.height * 0.5)
+
+                // Base: dois viewports lado a lado (Coronal e Sagital)
+                HStack(spacing: 6) {
+                    ZStack {
+                        MPRViewportView(controller: coronalVC).background(Color.black)
+                        CrosshairOverlay(
+                            onDragVertical: { width, t in
+                                // mover x'
+                                state.translate(alongBaseAxis: 0, deltaNormalized: Float(t.width / width))
+                                syncAll()
+                            },
+                            onDragHorizontal: { height, t in
+                                // mover z'
+                                state.translate(alongBaseAxis: 2, deltaNormalized: Float(-t.height / height))
+                                syncAll()
+                            },
+                            onRotate: { deltaRad in
+                                // girar ao redor de y' (normal do coronal)
+                                state.rotate(aroundBaseAxis: 1, deltaRadians: Float(deltaRad))
+                                syncAll()
+                            }
+                        )
+                    }
+                    ZStack {
+                        MPRViewportView(controller: sagittalVC).background(Color.black)
+                        CrosshairOverlay(
+                            onDragVertical: { width, t in
+                                // mover y'
+                                state.translate(alongBaseAxis: 1, deltaNormalized: Float(t.width / width))
+                                syncAll()
+                            },
+                            onDragHorizontal: { height, t in
+                                // mover z'
+                                state.translate(alongBaseAxis: 2, deltaNormalized: Float(-t.height / height))
+                                syncAll()
+                            },
+                            onRotate: { deltaRad in
+                                // girar ao redor de x' (normal do sagital)
+                                state.rotate(aroundBaseAxis: 0, deltaRadians: Float(deltaRad))
+                                syncAll()
+                            }
+                        )
+                    }
+                }
+                .frame(height: geo.size.height * 0.5)
+            }
+            .onAppear { syncAll() }
+        }
+    }
+}

--- a/VolumeRendering-iOS/Source/View/TriPlanarMPR.swift
+++ b/VolumeRendering-iOS/Source/View/TriPlanarMPR.swift
@@ -2,7 +2,7 @@
 //  Isis DICOM Viewer
 //
 //  Tri‑Planar MPR com linhas ortogonais arrastáveis e rotação oblíqua
-//  - 3 viewports 2D (axial, coronal, sagital) com SCNView ortográfico
+//  - 3 viewports 2D (axial, coronal, sagittal) com SCNView ortográfico
 //  - Reutiliza a textura 3D e a TF já carregadas pelo VR
 //  - Linhas centrais arrastáveis movem os planos; rotação 2‑toques gira a triade
 //


### PR DESCRIPTION
This pull request introduces a new Tri‑Planar MPR (Multi-Planar Reconstruction) feature to the iOS volume rendering app, allowing users to view and interact with three orthogonal 2D planes (axial, coronal, sagittal) simultaneously. The implementation includes a new SwiftUI view with draggable crosshair lines and support for oblique rotation, along with necessary project and UI updates to integrate this feature cleanly. The MPR replaces the previous single-slice MPR UI, streamlining navigation and enhancing usability.

**Tri‑Planar MPR Feature Implementation:**

* Added new `TriPlanarMPR.swift` file, which defines the Tri‑Planar MPR view, controllers for each plane, shared state management, and interactive overlays for crosshair navigation and oblique rotation. This enables synchronized navigation across three orthogonal planes and supports 2-finger rotation for oblique MPR.
* Updated `ContentView.swift` to conditionally display the new Tri‑Planar MPR panel when the MPR method is selected, falling back to the original 3D pipeline otherwise. The initialization logic ensures device and texture setup remains compatible.

**UI and Option Panel Adjustments:**

* Refined the options panel in `ContentView.swift` to remove the old single-slice MPR slider and plane picker when Tri‑Planar MPR is active. Instead, a concise instruction is shown, guiding users to navigate using the crosshair lines and rotation gesture.
* Clarified the use of transfer function and blend mode toggles, noting that the Tri‑Planar MPR observes and applies these settings to all three panels. [[1]](diffhunk://#diff-68d0b5583894db9d61f187f66ed10ebf63c7998c9a86dff7b88e4c3e889b59ffR181) [[2]](diffhunk://#diff-68d0b5583894db9d61f187f66ed10ebf63c7998c9a86dff7b88e4c3e889b59ffR200)

**Project Integration and Exposure:**

* Registered `TriPlanarMPR.swift` in the Xcode project file and included it in the build and source groups. [[1]](diffhunk://#diff-8b7520d736ff23ee8e933f5e2809220af16321e7a6c271011c84fd3e04fcd44eR10) [[2]](diffhunk://#diff-8b7520d736ff23ee8e933f5e2809220af16321e7a6c271011c84fd3e04fcd44eR38) [[3]](diffhunk://#diff-8b7520d736ff23ee8e933f5e2809220af16321e7a6c271011c84fd3e04fcd44eR109) [[4]](diffhunk://#diff-8b7520d736ff23ee8e933f5e2809220af16321e7a6c271011c84fd3e04fcd44eR287)
* Added minimal public accessors to `SceneViewController` to expose the current volume texture, transfer function texture, and dataset metadata, allowing the Tri‑Planar MPR to reuse these resources.

These changes collectively introduce a robust, interactive Tri‑Planar MPR feature, modernizing the MPR workflow and improving user experience for medical imaging review.